### PR TITLE
Prefer lower ids on ties

### DIFF
--- a/src/R_optics.cpp
+++ b/src/R_optics.cpp
@@ -145,10 +145,10 @@ List optics_int(NumericMatrix data, double eps, int minPts,
       for (std::vector<int>::iterator it = seeds.begin();
         it!=seeds.end(); ++it) {
         // Note: The second part of the if statement ensures that ties are
-        // always broken consistenty (higher ID wins to produce the same
+        // always broken consistenty (lower ID wins to produce the same
         // results as the elki implementation)!
         if (reachdist[*it] < reachdist[*q_it] ||
-          (reachdist[*it] == reachdist[*q_it] && *q_it < *it)) q_it = it;
+          (reachdist[*it] == reachdist[*q_it] && *it < *q_it)) q_it = it;
       }
       q = *q_it;
       seeds.erase(q_it);


### PR DESCRIPTION
This will change in the next ELKI release. It was intended to prefer lower IDs, and this "bug" (it's arbitrary, so it is not really a bug) has been fixed now.
Lower ids yields more expected results. In particular, if you reorder the data set to be in cluster order, and rerun OPTICS, the result should now be stable.