### PR TITLE
Fix kNNdistplot

### DIFF
--- a/R/kNN.R
+++ b/R/kNN.R
@@ -70,7 +70,7 @@ kNN <- function(x, k, sort = TRUE, search = "kdtree", bucketSize = 10,
   if(storage.mode(x) == "integer") storage.mode(x) <- "double"
   if(storage.mode(x) != "double") stop("x has to be a numeric matrix.")
 
-  if(k >= nrow(x)) stop("Not enought neighbors in data set!")
+  if(k >= nrow(x)) stop("Not enough neighbors in data set!")
 
 
   splitRule <- pmatch(toupper(splitRule), .ANNsplitRule)-1L

--- a/R/kNN.R
+++ b/R/kNN.R
@@ -51,7 +51,7 @@ kNN <- function(x, k, sort = TRUE, search = "kdtree", bucketSize = 10,
     x <- as.matrix(x)
     diag(x) <- NA
 
-    if(k >= nrow(x)) stop("Not enought neighbors in data set!")
+    if(k >= nrow(x)) stop("Not enough neighbors in data set!")
 
     o <- t(apply(x, 1, order, decreasing = FALSE))
     id <- o[,1:k, drop = FALSE]

--- a/R/kNNdist.R
+++ b/R/kNNdist.R
@@ -23,10 +23,9 @@ kNNdistplot <- function(x, k = 4, all.K = FALSE, ...) {
     # allow option of only plotting the kth distance for each observation
     if (!all.K){
       kNNdist <- sort(kNNdist(x, k ,...)[, k])
-  } else {
+    } else {
       kNNdist <- sort(kNNdist(x, k ,...))
-  }
-  
-  plot(sort(kNNdist), type="l", ylab=paste(k, "-NN distance", sep=""),
-    xlab = "Points (sample) sorted by distance")
+    }
+    plot(sort(kNNdist), type="l", ylab=paste(k, "-NN distance", sep=""),
+         xlab = "Points (sample) sorted by distance")
 }

--- a/R/kNNdist.R
+++ b/R/kNNdist.R
@@ -19,8 +19,14 @@
 
 kNNdist <- function(x, k, ...) dbscan::kNN(x, k, sort = TRUE, ...)$dist
 
-kNNdistplot <- function(x, k = 4, ...) {
-  kNNdist <- sort(kNNdist(x, k ,...))
+kNNdistplot <- function(x, k = 4, all.K = FALSE, ...) {
+    # allow option of only plotting the kth distance for each observation
+    if (!all.K){
+      kNNdist <- sort(kNNdist(x, k ,...)[, k])
+  } else {
+      kNNdist <- sort(kNNdist(x, k ,...))
+  }
+  
   plot(sort(kNNdist), type="l", ylab=paste(k, "-NN distance", sep=""),
     xlab = "Points (sample) sorted by distance")
 }


### PR DESCRIPTION
The kNNdistplot function uses the entire distance matrix (output from `kNNdist` function). I've changed it to only use the kth column when creating the line plot when the new argument all.K = FALSE. This was done by adding an argument, so the previous behavior of kNNdistplot can be produced by setting "all.K = TRUE". This aligns with most current methodologies. In addition, this change better aligns with the y-axis label, which states "kth-NN distances". Dr. Wenjen Zhou at The University of Tennessee helped discover this issue.

In addition, two small typos in KNN.R have been fixed. 