### PR TITLE
refactor: use more performant lengths instead of sapply(x, length)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,8 @@ Description: A fast reimplementation of several density-based algorithms of
     structure (from library ANN) for faster k-nearest neighbor search. An R 
     interface to fast kNN and fixed-radius NN search is also provided. 
     Hahsler, Piekenbrock and Doran (2019) <doi:10.18637/jss.v091.i01>.
+Depends:
+    R (>= 3.2.0)
 Imports:
     Rcpp (>= 1.0.0),
     graphics,

--- a/R/dbscan.R
+++ b/R/dbscan.R
@@ -422,4 +422,4 @@ print.dbscan_fast <- function(x, ...) {
 #' @rdname dbscan
 #' @export
 is.corepoint <- function(x, eps, minPts = 5, ...)
-  sapply(frNN(x, eps = eps, ...)$id, length) >= (minPts - 1)
+  lengths(frNN(x, eps = eps, ...)$id) >= (minPts - 1)

--- a/R/predict.R
+++ b/R/predict.R
@@ -84,10 +84,8 @@ predict.hdbscan <- function(object, newdata, data, ...) {
         "data contains factors! The factors are converted to numbers and euclidean distances are used"
       )
     }
-    data[indx] <- lapply(data[indx], function(x)
-      as.numeric(x))
-    newdata[indx] <- lapply(newdata[indx], function(x)
-      as.numeric(x))
+    data[indx] <- lapply(data[indx], as.numeric)
+    newdata[indx] <- lapply(newdata[indx], as.numeric)
   }
 
   # don't use noise

--- a/tests/testthat/test-frNN.R
+++ b/tests/testthat/test-frNN.R
@@ -24,7 +24,7 @@ expect_equal(nn$eps, eps)
 expect_equal(length(nn$dist), nrow(x))
 expect_equal(length(nn$id), nrow(x))
 
-expect_equal(sapply(nn$dist, length), sapply(nn$id, length))
+expect_equal(lengths(nn$dist), lengths(nn$id))
 
 ## check visually
 #plot(x)


### PR DESCRIPTION
Closes: https://github.com/mhahsler/dbscan/issues/61

This change would require R >= 3.2, but the description currently doesn't specify a specific R version