### PR TITLE
refactor: use seq_along and seq_len

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,5 +45,5 @@ Copyright: ANN library is copyright by University of Maryland, Sunil Arya and
     David Mount. All other code is copyright by Michael Hahsler and Matthew Piekenbrock.
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/R/NN.R
+++ b/R/NN.R
@@ -107,8 +107,8 @@ plot.NN <- function(x, data, main = NULL, pch = 16, col = NULL, linecol = "gray"
   ## use lines if it is from the same data
   ## FIXME: this test is not perfect, maybe we should have a parameter here or add the query points...
   if (length(id) == nrow(data)) {
-    for (i in 1:length(id)) {
-      for (j in 1:length(id[[i]]))
+    for (i in seq_along(id)) {
+      for (j in seq_along(id[[i]]))
         lines(x = c(data[i, 1], data[id[[i]][j], 1]),
           y = c(data[i, 2], data[id[[i]][j], 2]), col = linecol,
           ...)
@@ -121,7 +121,7 @@ plot.NN <- function(x, data, main = NULL, pch = 16, col = NULL, linecol = "gray"
     ## ad vertices
     points(data[, 1:2], main = main, pch = pch, ...)
     ## use colors if it was from a query
-    for (i in 1:length(id)) {
+    for (i in seq_along(id)) {
       points(data[id[[i]], ], pch = pch, col = i + 1L)
     }
   }

--- a/R/dbscan.R
+++ b/R/dbscan.R
@@ -349,7 +349,7 @@ dbscan <-
     if (length(frNN) > 0)
       frNN <-
       lapply(
-        1:length(frNN),
+        seq_along(frNN),
         FUN = function(i)
           c(i - 1L, frNN[[i]] - 1L)
       )

--- a/R/frNN.R
+++ b/R/frNN.R
@@ -126,7 +126,7 @@ frNN <-
       if (x$eps < eps)
         stop("frNN in x has not a sufficient eps radius.")
 
-      for (i in 1:length(x$dist)) {
+      for (i in seq_along(x$dist)) {
         take <- x$dist[[i]] <= eps
         x$dist[[i]] <- x$dist[[i]][take]
         x$id[[i]] <- x$id[[i]][take]
@@ -197,8 +197,8 @@ frNN <-
         )
       names(ret$dist) <- rownames(query)
       names(ret$id) <- rownames(query)
-      ret$metric = "euclidean"
-    } else{
+      ret$metric <- "euclidean"
+    } else {
       ret <- frNN_int(
         as.matrix(x),
         as.double(eps),
@@ -209,7 +209,7 @@ frNN <-
       )
       names(ret$dist) <- rownames(x)
       names(ret$id) <- rownames(x)
-      ret$metric = "euclidean"
+      ret$metric <- "euclidean"
     }
 
     ret$eps <- eps
@@ -288,19 +288,19 @@ sort.frNN <- function(x, decreasing = FALSE, ...) {
   n <- names(x$id)
 
   o <- lapply(
-    1:length(x$dist),
+    seq_along(x$dist),
     FUN =
       function(i)
         order(x$dist[[i]], x$id[[i]], decreasing = decreasing)
   )
   x$dist <-
     lapply(
-      1:length(o),
+      seq_along(o),
       FUN = function(p)
         x$dist[[p]][o[[p]]]
     )
   x$id <- lapply(
-    1:length(o),
+    seq_along(o),
     FUN = function(p)
       x$id[[p]][o[[p]]]
   )

--- a/R/frNN.R
+++ b/R/frNN.R
@@ -93,7 +93,7 @@
 #' i <- 10
 #' nn$id[[i]]
 #' nn$dist[[i]]
-#' plot(x, col = ifelse(1:nrow(iris) %in% nn$id[[i]], "red", "black"))
+#' plot(x, col = ifelse(seq_len(nrow(iris)) %in% nn$id[[i]], "red", "black"))
 #'
 #' # get an adjacency list
 #' head(adjacencylist(nn))

--- a/R/hullplot.R
+++ b/R/hullplot.R
@@ -133,7 +133,7 @@ hullplot <- function(x,
     ci_order <- 1:max(cl)
   }
 
-  for (i in 1:length(ci_order)) {
+  for (i in seq_along(ci_order)) {
     ### use all the points for xICSXi's hierarchical structure
     if (is.null(clusters_xi)) {
       d <- x[cl == i, , drop = FALSE]

--- a/R/kNN.R
+++ b/R/kNN.R
@@ -309,10 +309,10 @@ sort.kNN <- function(x, decreasing = FALSE, ...) {
 #' @export
 adjacencylist.kNN <- function(x, ...)
   lapply(
-    seq(nrow(x$id)),
+    seq_len(nrow(x$id)),
     FUN = function(i) {
       ## filter NAs
-      tmp <- x$id[i,]
+      tmp <- x$id[i, ]
       tmp[!is.na(tmp)]
     }
   )

--- a/R/kNN.R
+++ b/R/kNN.R
@@ -225,7 +225,7 @@ kNN <-
     if (sort)
       ret <- sort(ret)
 
-    ret$metric = "euclidean"
+    ret$metric <- "euclidean"
 
     ret
   }

--- a/R/kNN.R
+++ b/R/kNN.R
@@ -97,7 +97,7 @@
 #' # explore neighborhood of point 10
 #' i <- 10
 #' nn$id[i,]
-#' plot(x, col = ifelse(1:nrow(iris) %in% nn$id[i,], "red", "black"))
+#' plot(x, col = ifelse(seq_len(nrow(iris)) %in% nn$id[i,], "red", "black"))
 #'
 #' # visualize the 5 nearest neighbors
 #' plot(nn, x)
@@ -291,12 +291,12 @@ sort.kNN <- function(x, decreasing = FALSE, ...) {
 
   ## sort first by dist and break ties using id
   o <- sapply(
-    1:nrow(x$dist),
+    seq_len(nrow(x$dist)),
     FUN =
       function(i)
         order(x$dist[i,], x$id[i,], decreasing = decreasing)
   )
-  for (i in 1:ncol(o)) {
+  for (i in seq_len(ncol(o))) {
     x$dist[i,] <- x$dist[i,][o[, i]]
     x$id[i,] <- x$id[i,][o[, i]]
   }

--- a/R/optics.R
+++ b/R/optics.R
@@ -383,7 +383,7 @@ plot.optics <-
       )
 
       # Lines beneath plotting region indicating Xi clusters
-      i <- 1:nrow(hclusters)
+      i <- seq_len(nrow(hclusters))
       segments(
         x0 = hclusters$start[i],
         y0 = -(y_increments * i),
@@ -655,7 +655,7 @@ extractXi <-
       object$clusters_xi <-
         object$clusters_xi[order(object$clusters_xi$start, object$clusters_xi$end), ]
       object$clusters_xi <-
-        cbind(object$clusters_xi, list(cluster_id = 1:nrow(object$clusters_xi)))
+        cbind(object$clusters_xi, list(cluster_id = seq_len(nrow(object$clusters_xi))))
       row.names(object$clusters_xi) <- NULL
     }
 
@@ -720,7 +720,7 @@ extractClusterLabels <- function(cl, order, minimum = FALSE) {
   if (!all(c("start", "end") %in% names(cl)))
     stop("extractClusterLabels expects start and end references")
   if (!"cluster_id" %in% names(cl))
-    cl <- cbind(cl, cluster_id = 1:nrow(cl))
+    cl <- cbind(cl, cluster_id = seq_len(nrow(cl)))
 
   ## Sort cl based on minimum parameter / cluster size
   if (!"cluster_size" %in% names(cl))

--- a/R/optics.R
+++ b/R/optics.R
@@ -244,12 +244,12 @@ optics <- function(x, eps = NULL, minPts = 5, ...) {
     frNN <- frNN(x, eps, ...)
     ## add self match and use C numbering
     frNN$id <- lapply(
-      1:length(frNN$id),
+      seq_along(frNN$id),
       FUN = function(i)
         c(i - 1L, frNN$id[[i]] - 1L)
     )
     frNN$dist <- lapply(
-      1:length(frNN$dist),
+      seq_along(frNN$dist),
       FUN = function(i)
         c(0, frNN$dist[[i]]) ^ 2
     )

--- a/R/reachability.R
+++ b/R/reachability.R
@@ -104,7 +104,7 @@
 #' )
 #'
 #' plot(x, xlim = range(x), ylim = c(min(x) - sd(x), max(x) + sd(x)), pch = 20)
-#' text(x = x, labels = 1:nrow(x), pos = 3)
+#' text(x = x, labels = seq_len(nrow(x)), pos = 3)
 #'
 #' ### run OPTICS
 #' res <- optics(x, eps = 10,  minPts = 2)

--- a/R/reachability.R
+++ b/R/reachability.R
@@ -171,7 +171,7 @@ plot.reachability <- function(x,
     lty = 3)
   if (order_labels) {
     text(
-      x = 1:length(x$order),
+      x = seq_along(x$order),
       y = reachdist,
       labels = x$order,
       pos = 3

--- a/R/sNN.R
+++ b/R/sNN.R
@@ -182,11 +182,11 @@ sort.sNN <- function(x, decreasing = TRUE, ...) {
   ## sort first by number of shared points (decreasing) and break ties by id (increasing)
   k <- ncol(x$shared)
   o <- vapply(
-    1:nrow(x$shared),
+    seq_len(nrow(x$shared)),
     function(i) order(k - x$shared[i, ], x$id[i, ], decreasing = !decreasing),
     integer(k)
   )
-  for (i in 1:ncol(o)) {
+  for (i in seq_len(ncol(o))) {
     x$shared[i, ] <- x$shared[i, ][o[, i]]
     x$dist[i, ] <- x$dist[i, ][o[, i]]
     x$id[i, ] <- x$id[i, ][o[, i]]

--- a/R/sNNclust.R
+++ b/R/sNNclust.R
@@ -87,11 +87,11 @@
 #'
 #' @export
 sNNclust <- function(x, k, eps, minPts, borderPoints = TRUE, ...) {
-  nn <- sNN(x, k=k, jp = TRUE, ...)
+  nn <- sNN(x, k = k, jp = TRUE, ...)
 
   # convert into a frNN object which already enforces eps
-  nn_list <- lapply(seq(nrow(nn$id)),
-    FUN = function(i) unname(nn$id[i, nn$shared[i,] >= eps]))
+  nn_list <- lapply(seq_len(nrow(nn$id)),
+    FUN = function(i) unname(nn$id[i, nn$shared[i, ] >= eps]))
   snn <- structure(list(id = nn_list, eps = eps, metric = nn$metric),
     class = c("NN", "frNN"))
 
@@ -102,5 +102,5 @@ sNNclust <- function(x, k, eps, minPts, borderPoints = TRUE, ...) {
     type = "SharedNN clustering",
     param = list(k = k, eps = eps, minPts = minPts, borderPoints = borderPoints),
     metric = cl$metric),
-    class = c("general_clustering"))
+    class = "general_clustering")
 }

--- a/man/dbscan-package.Rd
+++ b/man/dbscan-package.Rd
@@ -28,7 +28,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Michael Hahsler \email{mhahsler@lyle.smu.edu} [copyright holder]
+\strong{Maintainer}: Michael Hahsler \email{mhahsler@lyle.smu.edu} (\href{https://orcid.org/0000-0003-2716-1405}{ORCID}) [copyright holder]
 
 Authors:
 \itemize{

--- a/man/frNN.Rd
+++ b/man/frNN.Rd
@@ -101,7 +101,7 @@ hist(lengths(adjacencylist(nn)),
 i <- 10
 nn$id[[i]]
 nn$dist[[i]]
-plot(x, col = ifelse(1:nrow(iris) \%in\% nn$id[[i]], "red", "black"))
+plot(x, col = ifelse(seq_len(nrow(iris)) \%in\% nn$id[[i]], "red", "black"))
 
 # get an adjacency list
 head(adjacencylist(nn))

--- a/man/kNN.Rd
+++ b/man/kNN.Rd
@@ -107,7 +107,7 @@ nn
 # explore neighborhood of point 10
 i <- 10
 nn$id[i,]
-plot(x, col = ifelse(1:nrow(iris) \%in\% nn$id[i,], "red", "black"))
+plot(x, col = ifelse(seq_len(nrow(iris)) \%in\% nn$id[i,], "red", "black"))
 
 # visualize the 5 nearest neighbors
 plot(nn, x)

--- a/man/reachability.Rd
+++ b/man/reachability.Rd
@@ -103,7 +103,7 @@ x <- cbind(
 )
 
 plot(x, xlim = range(x), ylim = c(min(x) - sd(x), max(x) + sd(x)), pch = 20)
-text(x = x, labels = 1:nrow(x), pos = 3)
+text(x = x, labels = seq_len(nrow(x)), pos = 3)
 
 ### run OPTICS
 res <- optics(x, eps = 10,  minPts = 2)

--- a/tests/testthat/test-frNN.R
+++ b/tests/testthat/test-frNN.R
@@ -10,7 +10,7 @@ test_that("frNN", {
   ## no duplicates first!
   #x <- x[!duplicated(x),]
 
-  rownames(x) <- paste0("Object_", 1:nrow(x))
+  rownames(x) <- paste0("Object_", seq_len(nrow(x)))
 
   eps <- .5
   nn <- frNN(x, eps = eps, sort = TRUE)
@@ -58,8 +58,8 @@ test_that("frNN", {
 
 
   ## add 100 copied points to check if self match filtering works
-  x <- rbind(x, x[sample(1:nrow(x), 100),])
-  rownames(x) <- paste0("Object_", 1:nrow(x))
+  x <- rbind(x, x[sample(seq_len(nrow(x)), 100),])
+  rownames(x) <- paste0("Object_", seq_len(nrow(x)))
 
   eps <- .5
   nn <- frNN(x, eps = eps, sort = TRUE)

--- a/tests/testthat/test-hdbscan.R
+++ b/tests/testthat/test-hdbscan.R
@@ -33,7 +33,7 @@ test_that("HDBSCAN", {
   }
 
   eps_values <- sort(res$hc$height, decreasing = TRUE)+.Machine$double.eps ## Machine eps for consistency between cuts
-  for (i in 1:length(eps_values)) {
+  for (i in seq_along(eps_values)) {
     cut_cl <- cut_tree(res$hc, eps_values[i], core_dist)
     dbscan_cl <- dbscan(moons, eps = eps_values[i], minPts = 5, borderPoints = FALSE) # DBSCAN* doesn't include border points
 

--- a/tests/testthat/test-kNN.R
+++ b/tests/testthat/test-kNN.R
@@ -10,7 +10,7 @@ test_that("kNN", {
   ## no duplicates first! All distances should be unique
   x <- x[!duplicated(x),]
 
-  rownames(x) <- paste0("Object_", 1:nrow(x))
+  rownames(x) <- paste0("Object_", seq_len(nrow(x)))
 
   k <- 5L
   nn <- kNN(x, k=k, sort = TRUE)
@@ -64,8 +64,8 @@ test_that("kNN", {
   ## the order is not stable with matching distances which means that the
   ## k-NN are not stable. We add 100 copied points to check if self match
   ## filtering and sort works
-  x <- rbind(x, x[sample(1:nrow(x), 100),])
-  rownames(x) <- paste0("Object_", 1:nrow(x))
+  x <- rbind(x, x[sample(seq_len(nrow(x)), 100),])
+  rownames(x) <- paste0("Object_", seq_len(nrow(x)))
 
   k <- 5L
   nn <- kNN(x, k=k, sort = TRUE)

--- a/tests/testthat/test-sNN.R
+++ b/tests/testthat/test-sNN.R
@@ -10,7 +10,7 @@ test_that("sNN", {
   ## no duplicates first!
   x <- x[!duplicated(x),]
 
-  rownames(x) <- paste0("Object_", 1:nrow(x))
+  rownames(x) <- paste0("Object_", seq_len(nrow(x)))
 
   k <- 5L
   nn <- sNN(x, k=k, sort = TRUE)
@@ -76,7 +76,7 @@ test_that("sNN", {
 
   # compute the sNN simularity in R
   ss <- matrix(nrow = nrow(x), ncol = nn$k)
-  for(i in 1:nrow(x))
+  for(i in seq_len(nrow(x)))
     for(j_ind in 1:nn$k)
       ss[i, j_ind] <- length(intersect(c(i, nn$id[i,]), nn$id[nn$id[i,j_ind],]))
 


### PR DESCRIPTION
Use safer (0 edge case) and slightly faster `seq_along(x)`, `seq_len(nrow(x))`, `seq_along(ncol(x))`

``` r
x <- rnorm(100)
bench::mark(1:length(x), seq_along(x))
#> # A tibble: 2 × 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 1:length(x)         0     41ns  9200446.        0B        0
#> 2 seq_along(x)        0      1ns 27803363.        0B        0
```

<sup>Created on 2024-07-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>