### PR TITLE
refactor: use is.infinite for checking infinity

### DIFF
--- a/R/dendrogram.R
+++ b/R/dendrogram.R
@@ -67,7 +67,7 @@ as.dendrogram.hdbscan <- function(object, ...) {
 #' @rdname dendrogram
 #' @export
 as.dendrogram.reachability <- function(object, ...) {
-  if (length(which(object$reachdist == Inf)) > 1)
+  if (sum(is.infinite(object$reachdist)) > 1)
     stop(
       "Multiple Infinite reachability distances found. Reachability plots can only be converted if they contain enough information to fully represent the dendrogram structure. If using OPTICS, a larger eps value (such as Inf) may be needed in the parameterization."
     )
@@ -88,8 +88,7 @@ as.dendrogram.reachability <- function(object, ...) {
 # from stats, but not exported
 # see stats:::midcache.dendrogram
 
-.midcache.dendrogram <- function (x, type = "hclust", quiet = FALSE)
-{
+.midcache.dendrogram <- function(x, type = "hclust", quiet = FALSE) {
   type <- match.arg(type)
   stopifnot(inherits(x, "dendrogram"))
   verbose <- getOption("verbose", 0) >= 2

--- a/R/optics.R
+++ b/R/optics.R
@@ -359,7 +359,7 @@ plot.optics <-
       par(mar = c(2, 4, 4, 2) + 0.1, omd = c(0, 1, .15, 1))
 
       # Need to know how to spread out lines
-      y_max <- max(x$reachdist[which(x$reachdist != Inf)])
+      y_max <- max(x$reachdist[!is.infinite(x$reachdist)])
       y_increments <- (y_max / 0.85 * .15) / (nrow(hclusters) + 1L)
 
       # Get top level cluster labels
@@ -418,7 +418,7 @@ as.dendrogram.optics <- function(object, ...) {
   if (object$minPts > length(object$order)) {
     stop("'minPts' should be less or equal to the points in the dataset.")
   }
-  if (length(which(object$reachdist == Inf)) > 1)
+  if (sum(is.infinite(object$reachdist)) > 1)
     stop(
       "Eps value is not large enough to capture the complete hiearchical structure of the dataset. Please use a large eps value (such as Inf)."
     )
@@ -529,7 +529,7 @@ extractXi <-
               Inf
           else
             object$ord_rd[index + 1]
-          if (esuccr != Inf) {
+          if (!is.infinite(esuccr)) {
             while (!is.na(object$order[index + 1])) {
               index <- index + 1
               if (steepUp(index, object)) {
@@ -540,7 +540,7 @@ extractXi <-
                     Inf
                 else
                   object$ord_rd[index + 1]
-                if (esuccr == Inf) {
+                if (is.infinite(esuccr)) {
                   endsteep <- endsteep - 1
                   break
                 }
@@ -571,7 +571,7 @@ extractXi <-
 
           # Credit to ELKI
           if (correctPredecessors) {
-            while (cend > cstart && object$ord_rd[cend] == Inf) {
+            while (cend > cstart && is.infinite(object$ord_rd[cend])) {
               cend <- cend - 1
             }
           }
@@ -684,7 +684,7 @@ updateFilterSDASet <- function(mib, sdaset, ixi) {
 # Determines if the reachability distance at the current index 'i' is
 # (xi) significantly lower than the next index
 steepUp <- function(i, object, ixi = object$ixi) {
-  if (object$ord_rd[i] >= Inf)
+  if (is.infinite(object$ord_rd[i]))
     return(FALSE)
   if (!valid(i + 1, object))
     return(TRUE)
@@ -696,7 +696,7 @@ steepUp <- function(i, object, ixi = object$ixi) {
 steepDown <- function(i, object, ixi = object$ixi) {
   if (!valid(i + 1, object))
     return(FALSE)
-  if (object$ord_rd[i + 1] >= Inf)
+  if (is.infinite(object$ord_rd[i + 1]))
     return(FALSE)
   return(object$ord_rd[i] * ixi >= object$ord_rd[i + 1])
 }

--- a/R/reachability.R
+++ b/R/reachability.R
@@ -133,7 +133,7 @@ NULL
 #' @rdname reachability
 #' @export
 print.reachability <- function(x, ...) {
-  avg_reach <- mean(x$reachdist[which(x$reachdist != Inf)], na.rm = TRUE)
+  avg_reach <- mean(x$reachdist[!is.infinite(x$reachdist)], na.rm = TRUE)
   cat(
     "Reachability plot collection for ",
     length(x$order),

--- a/tests/testthat/test-optics.R
+++ b/tests/testthat/test-optics.R
@@ -88,7 +88,7 @@ test_that("OPTICS", {
 
   # Make sure any epsilon that queries the entire neighborhood works,
   # error otherwise
-  max_rd <- max(res$reachdist[res$reachdist != Inf], na.rm = TRUE)
+  max_rd <- max(res$reachdist[!is.infinite(res$reachdist)], na.rm = TRUE)
   expect_error(as.dendrogram(optics(test_data, eps = max_rd-1e-7,  minPts = 2)), regexp = "Eps")
   expect_error(as.dendrogram(optics(test_data, eps = max_rd, minPts = nrow(test_data) + 1)), regexp = "'minPts'")
 


### PR DESCRIPTION
`is.infinite()` is generally faster than `x == Inf`, with the benefit of dealing with `NA`, but returning true for `-Inf`, which shouldn't have any relevance here.

``` r
x <- rep(Inf, 100)
bench::mark(x == Inf, is.infinite(x))
#> # A tibble: 2 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x == Inf           82ns    164ns  4668773.      448B        0
#> 2 is.infinite(x)     41ns    123ns  5606529.      448B        0
```

<sup>Created on 2024-07-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>