### PR TITLE
Add cluster_selection_epsilon

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,9 @@ Authors@R: c(person("Michael", "Hahsler", role = c("aut", "cre", "cph"),
                 comment = c(ORCID = "0000-0003-2716-1405")),
 	    person("Matthew", "Piekenbrock", role = c("aut", "cph")),
 	    person("Sunil", "Arya", role = c("ctb", "cph")),
-	    person("David", "Mount", role = c("ctb", "cph")))
+	    person("David", "Mount", role = c("ctb", "cph")),
+        person("Claudia", "Malzer", role = c("ctb")),
+        )
 Description: A fast reimplementation of several density-based algorithms of
     the DBSCAN family. Includes the clustering algorithms DBSCAN (density-based 
     spatial clustering of applications with noise) and HDBSCAN (hierarchical 

--- a/R/hdbscan.R
+++ b/R/hdbscan.R
@@ -66,6 +66,7 @@
 #' @param x a data matrix (Euclidean distances are used) or a [dist] object
 #' calculated with an arbitrary distance metric.
 #' @param minPts integer; Minimum size of clusters. See details.
+#' @param cluster_selection_epsilon double; a distance threshold below which no clusters should be selected, see Malzer & Baum 2020
 #' @param gen_hdbscan_tree logical; should the robust single linkage tree be
 #' explicitly computed (see cluster tree in Chaudhuri et al, 2010).
 #' @param gen_simplified_tree logical; should the simplified hierarchy be
@@ -109,6 +110,11 @@
 #' estimates for data clustering, visualization, and outlier detection.
 #' _ACM Transactions on Knowledge Discovery from Data (TKDD),_ 10(5):1-51.
 #' \doi{10.1145/2733381}
+#' 
+#' Malzer, C., & Baum, M. (2020). A Hybrid Approach To Hierarchical Density-based Cluster Selection. 
+#' In 2020 IEEE International Conference on Multisensor Fusion and Integration for Intelligent 
+#' Systems (MFI), pp. 223-228.
+#' \doi{10.1109/MFI49285.2020.9235263}
 #' @keywords model clustering hierarchical
 #' @examples
 #' ## cluster the moons data set with HDBSCAN
@@ -139,6 +145,7 @@
 #' @export
 hdbscan <- function(x,
   minPts,
+  cluster_selection_epsilon = 0.0,
   gen_hdbscan_tree = FALSE,
   gen_simplified_tree = FALSE,
   verbose = FALSE) {
@@ -167,7 +174,7 @@ hdbscan <- function(x,
   if (verbose)
     cat("Tree pruning...\n")
   res <- computeStability(hc, minPts, compute_glosh = TRUE)
-  res <- extractUnsupervised(res)
+  res <- extractUnsupervised(res, cluster_selection_epsilon=cluster_selection_epsilon)
   cl <- attr(res, "cluster")
 
   ## 4. Extract the clusters

--- a/src/buildHDBSCAN.cpp
+++ b/src/buildHDBSCAN.cpp
@@ -716,9 +716,9 @@ NumericVector fosc(List cl_tree, std::string cid, std::list<int>& sc, List cl_hi
       }
     }
 
-    double epsbirth = (double) cl["eps_birth"];
-    if (epsbirth < cluster_selection_epsilon){
-      keep_children = false; // prune
+    double epsdeath = (double) cl["eps_death"];
+    if (epsdeath < cluster_selection_epsilon){
+      keep_children = false; // prune children that emerge at distance below epsilon
     }
 
     // Prune children and add parent (cid) if need be

--- a/src/buildHDBSCAN.cpp
+++ b/src/buildHDBSCAN.cpp
@@ -635,6 +635,7 @@ double computeVirtualNode(IntegerVector noise, List constraints){
 // [[Rcpp::export]]
 NumericVector fosc(List cl_tree, std::string cid, std::list<int>& sc, List cl_hierarchy,
                    bool prune_unstable_leaves=false, // whether to prune -very- unstable subbranches
+                   double cluster_selection_epsilon = 0.0, // whether to prune subbranches below a given epsilon
                    const double alpha = 0, // mixed objective case
                    bool useVirtual = false, // return virtual node as well
                    const int n_constraints = 0, // number of constraints
@@ -655,7 +656,7 @@ NumericVector fosc(List cl_tree, std::string cid, std::list<int>& sc, List cl_hi
     IntegerVector child_ids = cl_hierarchy[cid];
     for (int i = 0, clen = child_ids.length(); i < clen; ++i){
       int child_id = child_ids.at(i);
-      scores = fosc(cl_tree, patch::to_string(child_id), sc, cl_hierarchy, prune_unstable_leaves, alpha, useVirtual, n_constraints, constraints);
+      scores = fosc(cl_tree, patch::to_string(child_id), sc, cl_hierarchy, prune_unstable_leaves, cluster_selection_epsilon, alpha, useVirtual, n_constraints, constraints);
       stability_scores.push_back(scores.at(0));
       constraint_scores.push_back(scores.at(1));
     }
@@ -715,6 +716,10 @@ NumericVector fosc(List cl_tree, std::string cid, std::list<int>& sc, List cl_hi
       }
     }
 
+    double epsbirth = (double) cl["eps_birth"];
+    if (epsbirth < cluster_selection_epsilon){
+      keep_children = false; // prune
+    }
 
     // Prune children and add parent (cid) if need be
     if (!keep_children && cid != "0") {
@@ -753,12 +758,12 @@ NumericVector fosc(List cl_tree, std::string cid, std::list<int>& sc, List cl_hi
 // extract the 'most stable' or salient flat cluster assignments. The large number of derivable
 // arguments due to fosc being a recursive function
 // [[Rcpp::export]]
-List extractUnsupervised(List cl_tree, bool prune_unstable = false){
+List extractUnsupervised(List cl_tree, bool prune_unstable = false, double cluster_selection_epsilon = 0.0){
   // Compute Salient Clusters
   std::list<int> sc = std::list<int>();
   List cl_hierarchy = cl_tree.attr("cl_hierarchy");
   int n = as<int>(cl_tree.attr("n"));
-  fosc(cl_tree, "0", sc, cl_hierarchy, prune_unstable); // Assume root node is always id == 0
+  fosc(cl_tree, "0", sc, cl_hierarchy, prune_unstable, cluster_selection_epsilon); // Assume root node is always id == 0
 
   // Store results as attributes
   cl_tree.attr("cluster") = getSalientAssignments(cl_tree, cl_hierarchy, sc, n); // Flat assignments
@@ -767,7 +772,7 @@ List extractUnsupervised(List cl_tree, bool prune_unstable = false){
 }
 
 // [[Rcpp::export]]
-List extractSemiSupervised(List cl_tree, List constraints, float alpha = 0, bool prune_unstable_leaves = false){
+List extractSemiSupervised(List cl_tree, List constraints, float alpha = 0, bool prune_unstable_leaves = false, double cluster_selection_epsilon = 0.0){
   // Rcout << "Starting semisupervised extraction..." << std::endl;
   List root = cl_tree["0"];
   List cl_hierarchy = cl_tree.attr("cl_hierarchy");
@@ -814,7 +819,7 @@ List extractSemiSupervised(List cl_tree, List constraints, float alpha = 0, bool
   }
 
   // First pass: compute unsupervised soln as a means of extracting normalizing constant J_U^*
-  cl_tree = extractUnsupervised(cl_tree, false);
+  cl_tree = extractUnsupervised(cl_tree, false, cluster_selection_epsilon);
   IntegerVector stable_sc = cl_tree.attr("salient_clusters");
   double total_stability = 0.0f;
   for (IntegerVector::iterator it = stable_sc.begin(); it != stable_sc.end(); ++it){
@@ -826,7 +831,7 @@ List extractSemiSupervised(List cl_tree, List constraints, float alpha = 0, bool
 
   // Compute stable clusters w/ instance-level constraints
   std::list<int> sc = std::list<int>();
-  fosc(cl_tree, "0", sc, cl_hierarchy, prune_unstable_leaves,
+  fosc(cl_tree, "0", sc, cl_hierarchy, prune_unstable_leaves, cluster_selection_epsilon,
        alpha, true, n_constraints, constraints); // semi-supervised parameters
 
   // Store results as attributes and return


### PR DESCRIPTION
This adds the cluster_selection_epsilon parameter as requested in [Issue 56 ](https://github.com/mhahsler/dbscan/issues/56).

Apparently, FOSC is implemented in this repository as a recursive top-down approach where the tree is pruned (keep_children=False) if stability prefers the parent node. So, I just added a simple epsilon check which sets keep_children to false if eps_birth is smaller than cluster_selection_epsilon. This should still return the most stable EOM clusters for parts of tree not affected by epsilon, which is important to achieve a hybrid version instead of just extracting DBSCAN* clusters (please double-check the changes to make sure I didn't miss anything!).

A simple test (note that this isn't the best demonstration dataset as you could just use dbscan instead of HDBSCAN(e) here, this is just for testing that the implementation works in general):

```
library(dbscan)
library(factoextra) # for multishapes

x <- multishapes[, 1:2]

set.seed(123)
mintPts <- 4

hdb <- hdbscan(x, minPts = mintPts, verbose=TRUE)
plot(hdb, show_flat = TRUE)
print(hdb)
plot(x, col=hdb$cluster+1, main="HDBSCAN")

hdbe <- hdbscan(x, minPts = mintPts, cluster_selection_epsilon=0.2, verbose=TRUE)
plot(hdbe, show_flat = TRUE)
print(hdbe)
plot(x, col=hdbe$cluster+1, main="HDBSCAN(e)")
```