### PR TITLE
refactor(src): finish std::iota migration, drop stale C++98 workaround in JP.cpp

### DIFF
--- a/src/JP.cpp
+++ b/src/JP.cpp
@@ -18,11 +18,7 @@ IntegerVector JP_int(IntegerMatrix nn, unsigned int kt) {
 
   // create label vector
   std::vector<int> label(n);
-  //iota is C++11 only
-  //std::iota(std::begin(label), std::end(label), 1); // Fill with 1, 2, ..., n.
-  int value = 1;
-  std::vector<int>::iterator first = label.begin(), last = label.end();
-  while(first != last) *first++ = value++;
+  std::iota(std::begin(label), std::end(label), 1); // Fill with 1, 2, ..., n.
 
   // create sorted sets so we can use set operations
   std::vector< std::set<int> > nn_set(nn.nrow());

--- a/src/connectedComps.cpp
+++ b/src/connectedComps.cpp
@@ -20,10 +20,6 @@ IntegerVector comps_kNN(IntegerMatrix nn, bool mutual) {
   // create label vector
   std::vector<int> label(n);
   std::iota(std::begin(label), std::end(label), 1); // Fill with 1, 2, ..., n.
-  //iota is C++11 only
-  //int value = 1;
-  //std::vector<int>::iterator first = label.begin(), last = label.end();
-  //while(first != last) *first++ = value++;
 
   // create sorted sets so we can use set operations
   std::vector< std::set<int> > nn_set(n);
@@ -76,10 +72,6 @@ IntegerVector comps_frNN(List nn, bool mutual) {
   // create label vector
   std::vector<int> label(n);
   std::iota(std::begin(label), std::end(label), 1); // Fill with 1, 2, ..., n.
-  //iota is C++11 only
-  //int value = 1;
-  //std::vector<int>::iterator first = label.begin(), last = label.end();
-  //while(first != last) *first++ = value++;
 
   // create sorted sets so we can use set operations
   std::vector< std::set<int> > nn_set(n);


### PR DESCRIPTION
project is already relying on C++11